### PR TITLE
Sequential polling and control of the polling cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ If you like my work, please consider a personal donation
 
 
 ## Changelog
+### 0.0.66      (24.12.2024)
+* (MrTomRocker) added sequential polling and the possibilty to control the polling cycles
+
 ### 0.0.65      (24.10.2024)
 * (homecineplexx) added new device DeltaDore-Zigbee-Stick-Easy Plug F16EM
 

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -105,8 +105,8 @@
                     <div class="row">
                         <div class="input-field col s12 m4 l3">
                             <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time_transmitters" class="value" size="3" maxlength="3" autocomplete="off"/>s -->
-                            <input placeholder="1" name="synchronization_transmitters" type="number" min="1" id="sync_time_transmitters" class="value validate" />
-                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time_transmitters">Synctime transmitters</label><span class="helper-text translate">s (default is 1)</span>
+                            <input placeholder="2" name="synchronization_transmitters" type="number" min="1" id="sync_time_transmitters" class="value validate" />
+                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time_transmitters">Synctime transmitters</label><span class="helper-text translate">s (default is 2)</span>
                         </div>
                         <div class="input-field col s12 m4 l3">
                             <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time_scenes" class="value" size="3" maxlength="3" autocomplete="off"/>s -->

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -22,7 +22,10 @@
             function load(settings, onChange) {
                 $('#homepilot_ip').val(settings.homepilotip).change(onChange);
                 $('#homepilot_port').val(settings.homepilotport).change(onChange);
-                $('#sync_time').val(settings.synctime).change(onChange);
+                $('#sync_time_actuators').val(settings.sync_actuators).change(onChange);
+                $('#sync_time_sensors').val(settings.sync_sensors).change(onChange);
+                $('#sync_time_transmitters').val(settings.sync_transmitters).change(onChange);
+                $('#sync_time_scenes').val(settings.sync_scenes).change(onChange);                                
 				$('#password').val(settings.password).change(onChange);
 				$('#isBridge').prop('checked',settings.isBridge).change(onChange);
 				
@@ -34,7 +37,10 @@
                 callback({
                     homepilotip: $('#homepilot_ip').val().trim(),
                     homepilotport: $('#homepilot_port').val().trim(),
-                    synctime: $('#sync_time').val().trim(),
+                    sync_actuators: $('#sync_time_actuators').val().trim(),
+                    sync_sensors: $('#sync_time_sensors').val().trim(),
+                    sync_scenes: $('#sync_time_scenes').val().trim(),
+                    sync_transmitters: $('#sync_time_transmitters').val().trim(),                                        
 					password: $('#password').val().trim(),
 					isBridge: $('#isBridge').prop('checked')
                 }); 
@@ -77,21 +83,37 @@
 			                <input name="homepilot_port" type="number" id="homepilot_port" class="value number validate"  />
 			                <label data-error="numbers only" data-success="ok" class="translate active" for="homepilot_port">Port</label><span class="helper-text translate">normally no port setting is required</span>
                          </div>
+                         <div class="input-field col s12 m6 l4">
+                            <input class="value" id="password" type="password">
+                            <label for="password" class="translate">Password</label>
+                         </div>
                     </div>
                     
                     <div class="row">
                         <div class="input-field col s12 m4 l3">
-                            <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time" class="value" size="3" maxlength="3" autocomplete="off"/>s -->
-                            <input placeholder="12" name="synchronization" type="number" id="sync_time" class="value validate" />
-                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time">Synctime</label><span class="helper-text translate">s (default is 12)</span>
+                            <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time_actuators" class="value" size="3" maxlength="3" autocomplete="off"/>s -->
+                            <input placeholder="4" name="synchronization_actuators" type="number" min="1" id="sync_time_actuators" class="value validate" />
+                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time_actuators">Synctime actuators</label><span class="helper-text translate">s (default is 4)</span>
                         </div>
-
-						<div class="input-field col s12 m6 l4">
-                           <input class="value" id="password" type="password">
-                           <label for="password" class="translate">Password</label>
-						</div>
+                        <div class="input-field col s12 m4 l3">
+                            <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time_sensors" class="value" size="3" maxlength="3" autocomplete="off"/>s -->
+                            <input placeholder="3" name="synchronization_sensors" type="number" min="1" id="sync_time_sensors" class="value validate" />
+                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time_sensors">Synctime sensors</label><span class="helper-text translate">s (default is 3)</span>
+                        </div>			
                     </div>
                     
+                    <div class="row">
+                        <div class="input-field col s12 m4 l3">
+                            <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time_transmitters" class="value" size="3" maxlength="3" autocomplete="off"/>s -->
+                            <input placeholder="1" name="synchronization_transmitters" type="number" min="1" id="sync_time_transmitters" class="value validate" />
+                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time_transmitters">Synctime transmitters</label><span class="helper-text translate">s (default is 1)</span>
+                        </div>
+                        <div class="input-field col s12 m4 l3">
+                            <!-- <input pattern="[0-9]{1,2,3}$" name="homepilot_ip_adress" type="number" id="sync_time_scenes" class="value" size="3" maxlength="3" autocomplete="off"/>s -->
+                            <input placeholder="5" name="synchronization_scenes" type="number" min="1" id="sync_time_scenes" class="value validate" />
+                            <label data-error="numbers only" data-success="ok" class="translate active" for="sync_time_scenes">Synctime scenes</label><span class="helper-text translate">s (default is 5)</span>
+                        </div>                        	
+                    </div>
 					<div class="row">
                        <div class="col s12 m4">
                              <input class="value" id="isBridge" type="checkbox">

--- a/docs/de/doc_homepilot20_de.md
+++ b/docs/de/doc_homepilot20_de.md
@@ -141,7 +141,7 @@ Gwünschte Zeit zwischen zwei Aktualisierungsabfragen der Szenen des Homepilot. 
 ### Sicherheit
 Seit dieser Version des Homepilot2 gibt es auch die Möglichkeit ein lokales Passwort zu setzen, welches dann hier im Adapter ebenfalls gleich gesetzt werden muß.
 
-### Finetuning des Abfragezyklus (pollig cycles)
+### Optionales Finetuning des Abfragezyklus (pollig cycles)
 #### Mögliche Gründe für ein Finetuning des Abfragezyklus
 1. Der Homepilot hat viele Geräte angeschlossen und die Web-Oberfläche oder die App sind sehr träge.
 2. Der Homepilot stürzt bei der Verwendung des Adapters ab und zu ab.

--- a/docs/de/doc_homepilot20_de.md
+++ b/docs/de/doc_homepilot20_de.md
@@ -142,22 +142,27 @@ Gwünschte Zeit zwischen zwei Aktualisierungsabfragen der Szenen des Homepilot. 
 Seit dieser Version des Homepilot2 gibt es auch die Möglichkeit ein lokales Passwort zu setzen, welches dann hier im Adapter ebenfalls gleich gesetzt werden muß.
 
 ### Finetuning des Abfragezyklus (pollig cycles)
-#### Möliche Gründe für ein Finetuning des Abfragezyklus
+#### Mögliche Gründe für ein Finetuning des Abfragezyklus
 1. Der Homepilot hat viele Geräte angeschlossen und die Web-Oberfläche oder die App sind sehr träge.
 2. Der Homepilot stürzt bei der Verwendung des Adapters ab und zu ab.
 3. Die Reaktion im IO-Broker auf Ereignisse der verwendeten Sender, wie z.B Wandtaster, etc. ist zu träge und soll schneller funktionieren.
 4. Optimierung der Kommunikations- und Rechenlast des IO-Broker.
 
 #### Grundlegende Funktionsweise des Abfragezyklus
-TODO
+Dieser Adapter aktualisiert die Zustände für Transmitter, Aktoren, Sensoren und Szenen gesondert. Da es sich beim Homepilot um ein Gerät handelt, welches gewisse Rechen- und Netzwerkressourcen hat, wird die Aktualisierung nacheinander ausgeführt, um parallele Anfragen an den Homepilot zu minimieren und diesen nicht zu stark zu beeinträchtigen.
+Der Adapter prüft jede Sekunde ob ein Aktualisierungsinterval für Transmitter, Aktoren, Sensoren oder Szenen ansteht und führt dies dann aus. Stehen z.B. für Transmitter und Sensoren zwei Aktualisierungsintervalle an, werden diese nacheinander ausgeführt. Dauert ein Aktualisierungszyklus länger wie eine Sekunde, so wird der nächste Aktualisierungszyklus blockiert und erst wieder ausgeführt, wenn die Bearbeitung des vorherigen Aktualisierungszyklus abgeschlossen ist.
+
+Über folgende Zustände im Objektbaum dieses Adapters kann der Aktualisierungszyklus beobachtet werden: 
+-  **homepilot20.X.station.Overall_Sync_Time**
+-  **homepilot20.X.station.Sync_Actuators_Time**
+-  **homepilot20.X.station.Sync_Sensors_Time**
+-  **homepilot20.X.station.Sync_Transmitters_Time**
+-  **homepilot20.X.station.Sync_Scenes_Time**
 
 #### Optimierungsmöglichkeiten
-TODO
-
-##### Synchronisationszeiten für Aktoren, Sensoren, Transmitter, 
-TODO
-
-##### Der Zustand "AutomaticRefreshAttribute"
-TODO
-
+Um den Abfragezyklus zu optimieren, können die Synchronisationszeiten für Aktoren, Sensoren, Transmitter und Szenen eingestellt werden. 
+Die Aktualisierung der Sensoren, Transmitter und Aktoren benötigt jeweils zwei Netzwerkanfragen an den IO Broker. Die Aktualisierung der Szenen benötigt eine Netzwerkanfrage. 
+Einige Transmitter, wie z.B. der DuoFern-Wandtaster-9494 benötigen noch eine weitere Netzwerkanfrage pro Gerät für zusätzliche Informationen wie z.B. Zeitstempel. 
+Wenn die Aktualisierung der zusätzlichen Informationen am Gerät nicht gewünscht oder benötigt wird, kann man im Objektbaum des Geräts folgenden Zustand auf false setzen: 
+**homepilot20.X.Transmitter.YY-ZZZZZZ.Attribute.AutomaticRefreshAttributes**
 

--- a/docs/de/doc_homepilot20_de.md
+++ b/docs/de/doc_homepilot20_de.md
@@ -126,8 +126,38 @@ Ab Version __0.0.3_ sind auch die Szenen vom Homepilot 2 abgebildet. Hier gibt e
 ### IP und Port
 Die IP Adresse der Homepilot Basisstation im lokalen Netzwerk. Ohne Eingabe verwendet der Adapter __homepilot.local__. Die Portnummer ist optional und wird nur bei Eingabe einer IP-Adresse berücksichtigt.
 
-### Synchronisation
-Dauer zwischen den Abfragen der Homepilot Basistation durch ioBroker. Die Eingabe ist optional. Standard ist 12s.
+### Synchronisationszeit Aktoren
+Gwünschte Zeit zwischen zwei Aktualisierungsabfragen der angeschlossenen Aktoren. Die Eingabe ist optional. Standard ist 4s.
+
+### Synchronisationszeit Sensoren
+Gwünschte Zeit zwischen zwei Aktualisierungsabfragen der angeschlossenen Sensoren. Die Eingabe ist optional. Standard ist 3s.
+
+### Synchronisationszeit Transmitter
+Gwünschte Zeit zwischen zwei Aktualisierungsabfragen der angeschlossenen Transmitter. Die Eingabe ist optional. Standard ist 2s.
+
+### Synchronisationszeit Szenen
+Gwünschte Zeit zwischen zwei Aktualisierungsabfragen der Szenen des Homepilot. Die Eingabe ist optional. Standard ist 5s.
 
 ### Sicherheit
 Seit dieser Version des Homepilot2 gibt es auch die Möglichkeit ein lokales Passwort zu setzen, welches dann hier im Adapter ebenfalls gleich gesetzt werden muß.
+
+### Finetuning des Abfragezyklus (pollig cycles)
+#### Möliche Gründe für ein Finetuning des Abfragezyklus
+1. Der Homepilot hat viele Geräte angeschlossen und die Web-Oberfläche oder die App sind sehr träge.
+2. Der Homepilot stürzt bei der Verwendung des Adapters ab und zu ab.
+3. Die Reaktion im IO-Broker auf Ereignisse der verwendeten Sender, wie z.B Wandtaster, etc. ist zu träge und soll schneller funktionieren.
+4. Optimierung der Kommunikations- und Rechenlast des IO-Broker.
+
+#### Grundlegende Funktionsweise des Abfragezyklus
+TODO
+
+#### Optimierungsmöglichkeiten
+TODO
+
+##### Synchronisationszeiten für Aktoren, Sensoren, Transmitter, 
+TODO
+
+##### Der Zustand "AutomaticRefreshAttribute"
+TODO
+
+

--- a/io-package.json
+++ b/io-package.json
@@ -528,7 +528,10 @@
     "native":{  
         "homepilotip":"",
         "homepilotport":"",
-        "synctime":"",
+        "sync_actuators": 4,
+        "sync_sensors": 3,
+        "sync_transmitters": 1,
+        "sync_scenes": 5,
 		"password":""
     },
     "objects": [],

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "homepilot20",
-        "version": "0.0.65",
+        "version": "0.0.66",
 		"news": {
           "0.0.65":{
             "en": "added new device DeltaDore-Zigbee-Stick-Easy Plug F16EM",
@@ -568,7 +568,22 @@
             },
             "native":{  
 			}
+      
         },
+        {  
+            "_id":"station.Sync_Sensors_Time",
+            "type":"state",
+            "common":{  
+                "name":"Synchronize sensors time",
+                "desc":"Last timestamp of synchronize sensors for performance optimization.",
+                "type":"string",
+                "role":"text",
+                "read":true,
+                "write":false
+            },
+            "native":{  
+			}
+        },        
         {  
             "_id":"Actuator-json",
             "type":"state",
@@ -582,7 +597,64 @@
             },
             "native":{  
 			}
+        },        
+        {  
+            "_id":"station.Sync_Actuators_Time",
+            "type":"state",
+            "common":{  
+                "name":"Synchronize actuators time",
+                "desc":"Last timestamp of synchronize actuators for performance optimization.",
+                "type":"string",
+                "role":"text",
+                "read":true,
+                "write":false
+            },
+            "native":{  
+			}
         },
+        {  
+            "_id":"station.Sync_Transmitters_Time",
+            "type":"state",
+            "common":{  
+                "name":"Synchronize transmitters time",
+                "desc":"Last timestamp of synchronize transmitters for performance optimization.",
+                "type":"string",
+                "role":"text",
+                "read":true,
+                "write":false
+            },
+            "native":{  
+			}        
+        },
+        {  
+            "_id":"station.Sync_Scenes_Time",
+            "type":"state",
+            "common":{  
+                "name":"Synchronize scenes time",
+                "desc":"Last timestamp of synchronize scenes for performance optimization.",
+                "type":"string",
+                "role":"text",
+                "read":true,
+                "write":false
+            },
+            "native":{  
+			}
+        },
+        {  
+            "_id":"station.Overall_Sync_Time",
+            "type":"state",
+            "common":{  
+                "name":"Overall sync time",
+                "desc":"Last timestamp of the overall sync for performance optimization.",
+                "type":"string",
+                "role":"text",
+                "read":true,
+                "write":false
+            },
+            "native":{  
+			}
+        },
+        
 		{  
             "_id":"Sensor-json",
             "type":"state",

--- a/io-package.json
+++ b/io-package.json
@@ -3,6 +3,9 @@
         "name": "homepilot20",
         "version": "0.0.66",
 		"news": {
+          "0.0.66":{
+            "en": "added sequential polling and the possibilty to control the polling cycles"
+          },
           "0.0.65":{
             "en": "added new device DeltaDore-Zigbee-Stick-Easy Plug F16EM",
             "de": "neues Gerät DeltaDore-Zigbee-Stick-Easy Plug F16EM hinzugefügt",

--- a/main.js
+++ b/main.js
@@ -2101,6 +2101,29 @@ function createTransmitterStates(result, type) {
 					native: {}
 				});
 		}	
+		if (deviceNumber == '32160211' /*DuoFern-Wandtaster-9494*/ ||
+			deviceNumber == '32501972' /*DuoFern-Mehrfachwandtaster*/		||
+		    deviceNumber == '12501006' /*Wandtaster-smart-3-Gruppen-12501006*/ ||
+		    deviceNumber == '12501001' /*Wandtaster-smart-1-Gruppe-12501001*/ ||
+			deviceNumber == '32501974' /*DuoFern-Mehrfachwandtaster-BAT-9494-1*/ ||
+			deviceNumber == '34810060' /*DuoFern-Handzentrale-9493*/ ||
+			deviceNumber == '32480366' /*DuoFern-Handsender-Standard-9491*/ ||
+			deviceNumber == '32480361' /*DuoFern-Handsender-Standard-9491-2*/ ||
+			deviceNumber == '32501973' /*DuoFern-Wandtaster-1-Kanal-9494-3*/) {
+				adapter.setObjectNotExists(path + '.Attribute.AutomaticRefreshAttributes', {
+					type: 'state',
+					common: {
+					   name: 'RefreshAttributes',
+						desc: 'Refresh the attributes, if transmiiters are polled for  ' + deviceId,
+						type: 'boolean',
+						role: 'text',
+						def: true,
+						read: true,
+						write: false
+					},
+					native: {}
+				});
+		}	
 	}
 	
 	path = undefined;
@@ -2833,48 +2856,54 @@ async function doAdditional(toDoList, type) {
 
 								case "32501972": /*DuoFern-Mehrfachwandtaster*/		
 								case "32501974": /*DuoFern-Mehrfachwandtaster-BAT-9494-1*/
-									elementJSON = await limitedGetSpecificAdditional(element);
-									var timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH1_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH1_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH2_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH2_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH3_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH3_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH4_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH4_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH5_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH5_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH6_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH6_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+									if(await IsAutomaticRefreshAttributesActivated(type + '.' + element + '-' + deviceNumberId)){										
+										elementJSON = await limitedGetSpecificAdditional(element);
+										var timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH1_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH1_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH2_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH2_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH3_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH3_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH4_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH4_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH5_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH5_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH6_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH6_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+									}
 									break;
 								
 								case "32160211": /*DuoFern-Wandtaster-9494*/
-									elementJSON = await limitedGetSpecificAdditional(element);
-									var timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_OFF_CH1_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_OFF_CH1_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_OFF_CH2_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_OFF_CH2_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_ON_CH1_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_ON_CH1_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_ON_CH2_EVT"))[0].timestamp;
-									doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_ON_CH2_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+									if(await IsAutomaticRefreshAttributesActivated(type + '.' + element + '-' + deviceNumberId)){										
+										elementJSON = await limitedGetSpecificAdditional(element);
+										var timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_OFF_CH1_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_OFF_CH1_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_OFF_CH2_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_OFF_CH2_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_ON_CH1_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_ON_CH1_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_ON_CH2_EVT"))[0].timestamp;
+										doAttributeWithTypeNumber(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_ON_CH2_EVT', timestamp, 'value.datetime', 'timestamp', hashMapName);
+									}
 									break;
-
+					
 								case "32501973": /*DuoFern-Wandtaster-1-Kanal-9494-3*/
-									elementJSON =await limitedGetSpecificAdditional(element);
-									var timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH1_EVT"))[0].timestamp;
-									doAttribute(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH1_EVT', timestamp, 'value.datetime', 'timestamp', false, "number", hashMapName);
-									
-									timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH2_EVT"))[0].timestamp;
-									doAttribute(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH2_EVT', timestamp, 'value.datetime', 'timestamp', false, "number", hashMapName);
+									if(await IsAutomaticRefreshAttributesActivated(type + '.' + element + '-' + deviceNumberId)){
+										elementJSON =await limitedGetSpecificAdditional(element);
+										var timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH1_EVT"))[0].timestamp;
+										doAttribute(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH1_EVT', timestamp, 'value.datetime', 'timestamp', false, "number", hashMapName);
+										
+										timestamp = (elementJSON.capabilities.filter((x)=>x.name === "KEY_PUSH_CH2_EVT"))[0].timestamp;
+										doAttribute(element, type + '.' + element + '-' + deviceNumberId + '.Attribute.', 'KEY_PUSH_CH2_EVT', timestamp, 'value.datetime', 'timestamp', false, "number", hashMapName);
+									}
 									break;
 									
 								default:
@@ -2907,6 +2936,19 @@ async function doAdditional(toDoList, type) {
 	});
 }
 
+async function IsAutomaticRefreshAttributesActivated(path){
+	const isActivatedState = await adapter.getStateAsync(path + '.Attribute.AutomaticRefreshAttributes');	
+	if(isActivatedState){
+		adapter.setState(path + '.Attribute.AutomaticRefreshAttributes', {
+			val: isActivatedState.val,
+			ack: true
+		});
+		if(isActivatedState.val){			
+			return true;
+		}
+	}	
+	return false;		
+}	
 
 async function doAttributeWithTypeNumber(did, path, name, value, role, description, hashMapName) {
 	doAttribute(did, path, name, value, role, description, false, "number", hashMapName);

--- a/main.js
+++ b/main.js
@@ -15,10 +15,10 @@ var writeStateHashmap = new HashMap();
 
 var lang = 'de';
 var ip = '';
-var sync_actuators = 12;
+var sync_actuators = 4;
 var sync_sensors = 3;
-var sync_transmitters = 7;
-var sync_scenes = 23;
+var sync_transmitters = 2;
+var sync_scenes = 5;
 var password;
 var saltedPassword;
 var passwordSalt;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.0.65",
+	"version": "0.0.66",
 	"name": "iobroker.homepilot20",
 	"author": {
 		"name": "Christian Koller-Kink",


### PR DESCRIPTION
This pull request fixes issue: https://github.com/homecineplexx/ioBroker.homepilot20/issues/60 and improves the performance of this very usefull adapter. It is now possible to read out some transmitters, like the "Mehrfachwandtaster" in one second cycles, without performance issues on the homepilot. 

I have 163 overall devices visible in the homepilot. 
![image](https://github.com/user-attachments/assets/274c9fa4-1b58-4697-a548-abca69841710)

I am using the Homepilot-2 with motor shutters, Schaltaktoren, dimmers, door contacts, a lot of "Mehrfachwandtaster", a HUE bridge, heating actors and an environment sensor. 
I have a multihost IO-Broker setup and the homepilot20 adapter is running in a docker hosted IObroker on a Synology DSM-720+, which generates high networkpressure to the homepilot.  

Due to the asynchronous character of the request( - command, I found out, that a lot of parallel requests are send to the Homepilot. In my case, with the current firmware this leads to following behaviour: 
- I cannot use the Web-UI and App of the Homepilot, if the adapter is active
- The Homepilot crashes at least twice a week, if the adapter is active

With the current firmware and my hardware setup, I couldn't use this adapter. That is why I tried to do a fix for the issue with the parallel requests. I have implemented a sequential polling cycle with async and await. I also have optimized the reuquests itself. 
It is possible to refresh most of the devices by accessing http://IP/v4/devices and http://IP/devices. But for some of the transmitters, like the "Mehrfachwandtaster" you also need to read the device itself to get the TIMESTAMP informations, e.g. KEY_PUSH_CH3_EVT.

**Changes:** 
1. Introduced the seuential poll cycle in the main function.
2. All Requests are now controlable over async / await
3. The sync times for each type (transmitters, sensors, etc..) are now configurable by the user.
4. Syncing of the additional information is now done via the "overall-request" on  http://IP/devices
5. For each "special transmitter" you can choose via an attribute "AutomaticRefreshAttributes", if you like to refresh the additional informatiosns with an extra http request
6. Adapted documentation

**Wishes:**
-  Please do the multilanguage thing in the changelog.
-  I tried to keep the changes in the style of the implementation of this adapter, to keep it understandable to the owner of this great repo. If you see any obstacles or have questions, just ask me please. 